### PR TITLE
Fix activesupport dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    hakiri (0.4.0)
-      active_support
+    hakiri (0.5.2)
+      activesupport
       bundler
       commander
       i18n
@@ -14,17 +14,17 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    active_support (3.0.0)
-      activesupport (= 3.0.0)
-    activesupport (3.0.0)
+    activesupport (3.2.14)
+      i18n (~> 0.6, >= 0.6.4)
+      multi_json (~> 1.0)
     cane (2.6.0)
       parallel
-    commander (4.1.3)
+    commander (4.1.5)
       highline (~> 1.6.11)
     highline (1.6.19)
-    i18n (0.6.4)
+    i18n (0.6.5)
     json_pure (1.8.0)
-    mime-types (1.23)
+    mime-types (1.25)
     minitest (5.0.6)
     multi_json (1.7.7)
     parallel (0.7.1)

--- a/hakiri.gemspec
+++ b/hakiri.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rake'
   s.add_dependency 'commander'
   s.add_dependency 'terminal-table'
-  s.add_dependency 'active_support'
+  s.add_dependency 'activesupport'
   s.add_dependency 'i18n'
   s.add_dependency 'rest-client'
   s.add_dependency 'json_pure'


### PR DESCRIPTION
This gem depends on [active_support](https://rubygems.org/gems/active_support) gem, which is the wrong dependency created by someone else, and oudated. Changing to the correct [activesupport](https://rubygems.org/gems/activesupport) dependency.
