### PR TITLE
Adding --json option which allows json only output.

### DIFF
--- a/bin/hakiri
+++ b/bin/hakiri
@@ -70,6 +70,7 @@ command 'gemfile:scan' do |c|
   c.option '--gemfile STRING', String, 'Path to your Gemfile.lock'
   c.option '--force', 'Force showing vulnerabilities without asking for it first.'
   c.option '--quiet', 'Only show vulnerability report'
+  c.option '--json', 'Output will be in JSON only.'
 
   c.action do |args, options|
     options.default :gemfile => './Gemfile.lock'

--- a/lib/hakiri/cli/cli.rb
+++ b/lib/hakiri/cli/cli.rb
@@ -10,6 +10,6 @@ class Hakiri::Cli
   end
   
   def say_q msg
-    say msg unless @options.quiet
+    say msg unless @options.quiet or @options.json
   end
 end

--- a/lib/hakiri/cli/gemfile.rb
+++ b/lib/hakiri/cli/gemfile.rb
@@ -4,7 +4,7 @@ class Hakiri::Gemfile < Hakiri::Cli
   #
   def scan
     if File.exist? @options.gemfile
-      @stack.build_from_gemfile(@options.gemfile)
+      @stack.build_from_gemfile(@options)
 
       if @stack.technologies.empty?
         say '       No gems were found in your Gemfile.lock...'
@@ -26,27 +26,31 @@ class Hakiri::Gemfile < Hakiri::Cli
           authenticated = response[:meta][:authenticated]
 
           if response[:technologies].empty?
-            say '       No vulnerabilities found. Keep it up!'
+            say_q '       No vulnerabilities found. Keep it up!'
           else
             response[:technologies].each do |technology|
               unless technology[:issues_count] == 0
-                say "!      Found #{technology[:issues_count].to_i} #{'vulnerability'.pluralize if technology[:issues_count].to_i != 1} in #{technology[:name]} #{technology[:version]}"
+                say_q "!      Found #{technology[:issues_count].to_i} #{'vulnerability'.pluralize if technology[:issues_count].to_i != 1} in #{technology[:name]} #{technology[:version]}"
               end
             end
 
-            if @options.force || agree('Show all of them? (yes or no) ')
-              puts ' '
-              response[:technologies].each do |technology|
-                technology[:issues].each do |issue|
-                  say issue[:name]
-                  puts issue[:description]
-                  puts ' '
+            if @options.json || @options.force || agree('Show all of them? (yes or no) ')
+              say_q ' '
+              if @options.json then
+                puts response.to_json
+              else
+                response[:technologies].each do |technology|
+                  technology[:issues].each do |issue|
+                    say issue[:name]
+                    puts issue[:description]
+                    puts ' '
+                  end
                 end
               end
             end
 
             unless authenticated
-              say '****** Signup on hakiri.io to get notified when new vulnerabilities come out.'
+              say_q '****** Signup on hakiri.io to get notified when new vulnerabilities come out.'
             end
           end
         end


### PR DESCRIPTION
Allows the results to be used programmatically. Example (running hakiri against netflix/Scumblr):
```json
git/Scumblr$ hakiri gemfile:scan --json | jq .
{
  "meta": {
    "authenticated": false
  },
  "technologies": [
    {
      "id": 24,
      "name": "crack",
      "version": "0.1.8",
      "issues_count": 1,
      "issues": [
        {
          "id": null,
          "cve_id": "2013-1800",
          "description": "crack Gem for Ruby contains a flaw that is triggered when a type casting\nerror occurs during the parsing of parameters. This may allow a\ncontext-dependent attacker to potentially execute arbitrary code.\n",
          "level": "7.5",
          "published_date": "2013-04-09T20:55:01.927Z",
          "osvdb_id": "90742",
          "name": "CVE-2013-1800 / OSVDB-90742"
        }
      ]
    },
    {
      "id": 738,
      "name": "http",
      "version": "0.6.2",
      "issues_count": 1,
      "issues": [
        {
          "id": null,
          "cve_id": "2015-1828",
          "description": "http.rb failed to call the OpenSSL::SSL::SSLSocket#post_connection_check method to perform hostname verification.\r\nBecause of this, an attacker with a valid certificate but with a mismatched subject can perform a MitM attack.\r\n",
          "level": "5.0",
          "published_date": "2015-03-24T00:00:00.000Z",
          "osvdb_id": "119927",
          "name": "CVE-2015-1828 / OSVDB-119927"
        }
      ]
    },
    {
      "id": 113,
      "name": "nokogiri",
      "version": "1.6.8.1",
      "issues_count": 1,
      "issues": [
        {
          "id": null,
          "cve_id": "2016-4658",
          "description": "Nokogiri version 1.7.1 has been released, pulling in several upstream\r\npatches to the vendored libxml2 to address the following CVEs:\r\n\r\nCVE-2016-4658\r\nCVSS v3 Base Score: 9.8 (Critical)\r\nlibxml2 in Apple iOS before 10, OS X before 10.12, tvOS before 10, and\r\nwatchOS before 3 allows remote attackers to execute arbitrary code or cause\r\na denial of service (memory corruption) via a crafted XML document.\r\n\r\nCVE-2016-5131\r\nCVSS v3 Base Score: 8.8 (HIGH)\r\nUse-after-free vulnerability in libxml2 through 2.9.4, as used in Google\r\nChrome before 52.0.2743.82, allows remote attackers to cause a denial of\r\nservice or possibly have unspecified other impact via vectors related to\r\nthe XPointer range-to function.\r\n",
          "level": "9.8",
          "published_date": "2017-03-11T00:00:00.000Z",
          "osvdb_id": "",
          "name": "CVE-2016-4658"
        }
      ]
    },
    {
      "id": 368,
      "name": "paperclip",
      "version": "4.2.0",
      "issues_count": 1,
      "issues": [
        {
          "id": null,
          "cve_id": "2015-2963",
          "description": "There is an issue where if an HTML file is uploaded with a .html\nextension, but the content type is listed as being `image/jpeg`, this\nwill bypass a validation checking for images. But it will also pass the\nspoof check, because a file named .html and containing actual HTML\npasses the spoof check.\n",
          "level": "4.3",
          "published_date": "2015-07-10T17:59:00.093Z",
          "osvdb_id": "",
          "name": "CVE-2015-2963"
        }
      ]
    },
    {
      "id": 378,
      "name": "rack-mini-profiler",
      "version": "0.9.1",
      "issues_count": 1,
      "issues": [
        {
          "id": null,
          "cve_id": "2016-4442",
          "description": "Carefully crafted requests can expose information about strings and objects allocated during the request for unauthorised users.",
          "level": "5.0",
          "published_date": "2016-05-18T00:00:00.000Z",
          "osvdb_id": "",
          "name": "CVE-2016-4442"
        }
      ]
    },
    {
      "id": 1,
      "name": "rails",
      "version": "4.2.6",
      "issues_count": 2,
      "issues": [
        {
          "id": null,
          "cve_id": "2016-6316",
          "description": "There is a possible XSS vulnerability in Action View.  Text declared as \"HTML\nsafe\" will not have quotes escaped when used as attribute values in tag\nhelpers.\n\nImpact\n------\n\nText declared as \"HTML safe\" when passed as an attribute value to a tag helper\nwill not have quotes escaped which can lead to an XSS attack.  Impacted code\nlooks something like this:\n\n```ruby\ncontent_tag(:div, \"hi\", title: user_input.html_safe)\n```\n\nSome helpers like the `sanitize` helper will automatically mark strings as\n\"HTML safe\", so impacted code could also look something like this:\n\n```ruby\ncontent_tag(:div, \"hi\", title: sanitize(user_input))\n```\n\nAll users running an affected release should either upgrade or use one of the\nworkarounds immediately.\n\nWorkarounds\n-----------\nYou can work around this issue by either *not* marking arbitrary user input as\nsafe, or by manually escaping quotes like this:\n\n```ruby\ndef escape_quotes(value)\n  value.gsub(/\"/, '&quot;'.freeze)\nend\n\ncontent_tag(:div, \"hi\", title: escape_quotes(sanitize(user_input)))\n```\n",
          "level": "4.3",
          "published_date": "2016-08-11T17:00:00.000Z",
          "osvdb_id": "",
          "name": "CVE-2016-6316"
        },
        {
          "id": null,
          "cve_id": "2016-6317",
          "description": "There is a vulnerability when Active Record is used in conjunction with JSON\nparameter parsing. This vulnerability is similar to CVE-2012-2660,\nCVE-2012-2694 and CVE-2013-0155.\n\nImpact\n------\n\nDue to the way Active Record interprets parameters in combination with the way\nthat JSON parameters are parsed, it is possible for an attacker to issue\nunexpected database queries with \"IS NULL\" or empty where clauses.  This issue\ndoes *not* let an attacker insert arbitrary values into an SQL query, however\nthey can cause the query to check for NULL or eliminate a WHERE clause when\nmost users wouldn't expect it.\n\nFor example, a system has password reset with token functionality:\n\n```ruby\n    unless params[:token].nil?\n      user = User.find_by_token(params[:token])\n      user.reset_password!\n    end\n```\n\nAn attacker can craft a request such that `params[:token]` will return\n`[nil]`.  The `[nil]` value will bypass the test for nil, but will still add\nan \"IN ('xyz', NULL)\" clause to the SQL query.\n\nSimilarly, an attacker can craft a request such that `params[:token]` will\nreturn an empty hash.  An empty hash will eliminate the WHERE clause of the\nquery, but can bypass the `nil?` check.\n\nNote that this impacts not only dynamic finders (`find_by_*`) but also\nrelations (`User.where(:name => params[:name])`).\n\nAll users running an affected release should either upgrade or use one of the\nwork arounds immediately. All users running an affected release should upgrade\nimmediately. Please note, this vulnerability is a variant of CVE-2012-2660,\nCVE-2012-2694, and CVE-2013-0155.  Even if you upgraded to address those\nissues, you must take action again.\n\nIf this chance in behavior impacts your application, you can manually decode\nthe original values from the request like so:\n\n    `ActiveSupport::JSON.decode(request.body)`\n\nWorkarounds\n-----------\nThis problem can be mitigated by casting the parameter to a string before\npassing it to Active Record.  For example:\n\n  ```ruby\n    unless params[:token].nil? || params[:token].to_s.empty?\n      user = User.find_by_token(params[:token].to_s)\n      user.reset_password!\n    end\n  ```\n",
          "level": "5.0",
          "published_date": "2016-08-11T17:00:00.000Z",
          "osvdb_id": "",
          "name": "CVE-2016-6317"
        }
      ]
    },
    {
      "id": 145,
      "name": "sprockets",
      "version": "2.11.0",
      "issues_count": 1,
      "issues": [
        {
          "id": null,
          "cve_id": "2014-7819",
          "description": "Specially crafted requests can be used to determine whether a file exists on\nthe filesystem that is outside an application's root directory.  The files\nwill not be served, but attackers can determine whether or not the file\nexists.\n",
          "level": "5.0",
          "published_date": "2014-11-08T11:55:03.023Z",
          "osvdb_id": "113965",
          "name": "CVE-2014-7819 / OSVDB-113965"
        }
      ]
    },
    {
      "id": 156,
      "name": "uglifier",
      "version": "2.5.3",
      "issues_count": 1,
      "issues": [
        {
          "id": null,
          "cve_id": "",
          "description": "\r\nThe upstream library for the Ruby uglifier gem, UglifyJS, is\r\naffected by a vulnerability that allows a specially crafted \r\nJavascript file to have altered functionality after minification.\r\n\r\nThis bug, found in UglifyJS versions 2.4.23 and earlier, was demonstrated\r\nto allow potentially malicious code to be hidden within secure code, \r\nand activated by the minification process.\r\n\r\nFor more information, consult: https://zyan.scripts.mit.edu/blog/backdooring-js/\r\n",
          "level": "4.0",
          "published_date": "2015-07-21T00:00:00.000Z",
          "osvdb_id": "126747",
          "name": "OSVDB-126747"
        }
      ]
    }
  ]
}
```